### PR TITLE
[WIP] Support Python 3

### DIFF
--- a/waveform-modeling/WaveNet-scripts/SCRIPTS/sub_01_prepare_list.py
+++ b/waveform-modeling/WaveNet-scripts/SCRIPTS/sub_01_prepare_list.py
@@ -2,6 +2,7 @@
 """
 """
 
+from __future__ import absolute_import
 import os
 import sys
 import imp

--- a/waveform-modeling/WaveNet-scripts/SCRIPTS/sub_06_norm_acousticfeature.py
+++ b/waveform-modeling/WaveNet-scripts/SCRIPTS/sub_06_norm_acousticfeature.py
@@ -1,15 +1,18 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 import imp
 from ioTools import readwrite as py_rw
+from six.moves import zip
 
 try:
     meanStdToolPath = sys.argv[9] + os.path.sep + 'dataProcess'
     meanStdTool = imp.load_source('meanStd', meanStdToolPath + os.path.sep + 'meanStd.py')
 except ImportError:
-    print "Cannot found %s/dataProcess" % (sys.argv[9])
+    print("Cannot found %s/dataProcess" % (sys.argv[9]))
         
 if __name__ == "__main__":
     dataLst = sys.argv[1]
@@ -65,8 +68,8 @@ if __name__ == "__main__":
     
     meanstd_data = py_rw.read_raw_mat(mvoutputPath, 1)
     if f0Dim >= 0:
-        print "Please note:"
-        print "F0 mean: %f" % (meanstd_data[f0Dim])
-        print "F0 std: %f" % (meanstd_data[dimCnt+f0Dim])
+        print("Please note:")
+        print("F0 mean: %f" % (meanstd_data[f0Dim]))
+        print("F0 std: %f" % (meanstd_data[dimCnt+f0Dim]))
 
 

--- a/waveform-modeling/WaveNet-scripts/SCRIPTS/sub_07_getf0meanstd.py
+++ b/waveform-modeling/WaveNet-scripts/SCRIPTS/sub_07_getf0meanstd.py
@@ -1,8 +1,11 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 from ioTools import readwrite as py_rw
+from six.moves import zip
 
 if __name__ == "__main__":
     meanstd_data = sys.argv[1]
@@ -27,6 +30,6 @@ if __name__ == "__main__":
     meanstd_data = py_rw.read_raw_mat(meanstd_data, 1)
     
     if f0Dim >= 0:
-        print "%f %f" % (meanstd_data[f0Dim], meanstd_data[dimCnt+f0Dim])
+        print("%f %f" % (meanstd_data[f0Dim], meanstd_data[dimCnt+f0Dim]))
 
 


### PR DESCRIPTION
Python 2 files were automatically converted with `modernize`
https://github.com/python-modernize/python-modernize .

```
python-modernize -w -n project-CURRENNT-scripts/waveform-modeling/WaveNet-scripts/SCRIPTS
```

ToDo: convert other scripts.

- [ ] NSF-pretrained
- [ ] NSF-scripts
- [ ] WaveNet-pretrained
- [x] WaveNet-scripts